### PR TITLE
feat: organizations management

### DIFF
--- a/app/assets/legacy/account-profile.js
+++ b/app/assets/legacy/account-profile.js
@@ -213,6 +213,19 @@ ready(() => {
         );
       },
     });
+    $('#organization_id').editable({
+      success: function (msg, newValue) {
+        return doAjaxRequest(
+          $('#organization_id'),
+          {
+            organization_id: newValue,
+          },
+          function (msg) {
+            return $('#organization_id').html(msg.organization_id);
+          },
+        );
+      },
+    });
 
     $('#secondary-emails-list').hide();
     $('#secondary-emails-hide-button').hide();

--- a/app/controllers/account/profiles_controller.rb
+++ b/app/controllers/account/profiles_controller.rb
@@ -7,7 +7,7 @@ class Account::ProfilesController < Abstract::FrontendController
   before_action :ensure_logged_in
   include Interruptible
 
-  USER_KEYS = %i[full_name display_name born_at].freeze
+  USER_KEYS = %i[full_name display_name born_at organization_id].freeze
 
   def show
     user = find_user

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Admin::OrganizationsController < Abstract::FrontendController
+  require_permission 'account.organizations.manage'
+
+  def index
+    @organizations = Account::Organization.order(:name).paginate(page: params[:page] || 1, per_page: 50)
+  end
+
+  def new
+    @organization = Account::Organization.new
+  end
+
+  def edit
+    @organization = Account::Organization.find(params[:id])
+  end
+
+  def create
+    account_api.rel(:organizations).post(organization_params.to_h).value!
+    add_flash_message :success, I18n.t(:'flash.success.organization_created')
+    redirect_to admin_organizations_path
+  rescue Restify::ClientError
+    add_flash_message :error, I18n.t(:'flash.error.organization_not_created')
+    redirect_to admin_organizations_path
+  end
+
+  def update
+    account_api.rel(:organization).patch(organization_params.to_h, params: {id: params[:id]}).value!
+    add_flash_message :success, I18n.t(:'flash.success.organization_updated')
+    redirect_to admin_organizations_path
+  rescue Restify::ClientError
+    add_flash_message :error, I18n.t(:'flash.error.organization_not_updated')
+    redirect_to admin_organizations_path
+  end
+
+  def destroy
+    account_api.rel(:organization).delete({id: params[:id]}).value!
+    add_flash_message :success, I18n.t(:'flash.success.organization_deleted')
+    redirect_to admin_organizations_path
+  rescue Restify::ClientError
+    add_flash_message :error, I18n.t(:'flash.error.organization_not_deleted')
+    redirect_to admin_organizations_path
+  end
+
+  def export
+    organizations = Account::Organization.order(:name)
+
+    csv_data = CSV.generate(col_sep: ';') do |csv|
+      organizations.each do |organization|
+        csv << [organization.name]
+      end
+    end
+
+    send_data(
+      csv_data,
+      filename: 'organizations.csv',
+      type: 'text/csv',
+      disposition: 'attachment'
+    )
+  end
+
+  private
+
+  def organization_params
+    params.require(:account_organization).permit(:name)
+  end
+
+  def account_api
+    @account_api ||= Xikolo.api(:account).value!
+  end
+end

--- a/app/controllers/concerns/interruptible.rb
+++ b/app/controllers/concerns/interruptible.rb
@@ -24,6 +24,7 @@ module Interruptible
   INTERRUPT_LOCATIONS = {
     'new_consents' => {controller: 'account/treatments', action: 'index'},
     'new_policy' => {controller: 'account/policies', action: 'show'},
+    'unselected_organization' => {controller: 'account/profiles', action: 'show'},
     'mandatory_profile_fields' => {controller: 'account/profiles', action: 'show'},
   }.freeze
 
@@ -50,7 +51,7 @@ module Interruptible
 
   def known_interrupts
     @known_interrupts ||= INTERRUPT_LOCATIONS.keys & current_user.interrupts.select do |i|
-      i != 'mandatory_profile_fields' || current_user.feature?('profile')
+      (i != 'mandatory_profile_fields' && i != 'unselected_organization') || current_user.feature?('profile')
     end
   end
 

--- a/app/models/account/organization.rb
+++ b/app/models/account/organization.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Account
+  class Organization < ::ApplicationRecord
+  end
+end

--- a/app/models/account/organization.rb
+++ b/app/models/account/organization.rb
@@ -2,5 +2,8 @@
 
 module Account
   class Organization < ::ApplicationRecord
+    has_many :users,
+      class_name: 'Account::User',
+      dependent: :nullify
   end
 end

--- a/app/models/account/user.rb
+++ b/app/models/account/user.rb
@@ -24,6 +24,10 @@ module Account
       class_name: '::Certificate::Record',
       dependent: :destroy
 
+    belongs_to :organization,
+      class_name: 'Account::Organization',
+      optional: true
+
     def self.with_authorization(uid)
       joins(:authorizations).where(authorizations: {uid:})
     end

--- a/app/presenters/account/profile_presenter.rb
+++ b/app/presenters/account/profile_presenter.rb
@@ -41,6 +41,16 @@ class Account::ProfilePresenter < Presenter
     @user.born_at
   end
 
+  def organization_id
+    @user.organization_id
+  end
+
+  def organizations_json
+    Account::Organization.all.map do |organization|
+      {value: organization.id, text: organization.name}
+    end.to_json
+  end
+
   def unconfirmed_emails?
     unconfirmed_emails.any?
   end

--- a/app/presenters/admin_navigation.rb
+++ b/app/presenters/admin_navigation.rb
@@ -71,4 +71,8 @@ class AdminNavigation < MenuWithPermissions
       Xikolo.config.voucher['enabled'] && user.allowed?('course.vouchers.issue', context: :root)
     },
     route: :vouchers
+
+  item 'header.navigation.admin.organizations', 'city',
+    if: ->(user, _course) { user.allowed? 'account.organizations.manage', context: :root },
+    route: :admin_organizations
 end

--- a/app/views/account/profiles/show.html.slim
+++ b/app/views/account/profiles/show.html.slim
@@ -104,6 +104,11 @@
         small
           = t(:'dashboard.profile.show_birthdate_on_record', url: dashboard_documents_path)
 
+    h4.pt5
+      = t(:'dashboard.profile.organization')
+    p
+      a#organization_id.status href='#' data-type='select' data-url=dashboard_profile_path data-name='organization_id' pk='organization_id' data-value=@profile.organization_id data-source=@profile.organizations_json data-emptytext=t(:'dashboard.profile.not_set') aria-describedby='description-edit'
+
     - if @profile.required_fields.any?
       h4.pt5
         = t(:'dashboard.profile.required_info')

--- a/app/views/admin/organizations/_form.html.slim
+++ b/app/views/admin/organizations/_form.html.slim
@@ -1,0 +1,6 @@
+= simple_form_for(organization, url: organization.persisted? ? admin_organization_path(id: organization.id) : admin_organizations_path) do |f|
+  = f.error_notification
+  = f.input :id, as: :hidden
+  = f.input :name, autofocus: true
+  = f.submit class: 'btn btn-primary'
+  = link_to t(:'global.cancel'), admin_organizations_path, class: 'btn btn-default ml10'

--- a/app/views/admin/organizations/edit.html.slim
+++ b/app/views/admin/organizations/edit.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_header_slim
+= render Global::PageHeader.new(t(:'admin.organizations.headline'), subtitle: t(:'admin.page_header'), type: :slim)
+
+.container
+  .row
+    .col-md-12
+      h2
+        = t(:'admin.organizations.edit')
+      = render 'admin/organizations/form', organization: @organization

--- a/app/views/admin/organizations/index.html.slim
+++ b/app/views/admin/organizations/index.html.slim
@@ -1,0 +1,30 @@
+- content_for :page_header_slim
+= render Global::PageHeader.new(t(:'admin.organizations.headline'), subtitle: t(:'admin.page_header'), type: :slim)
+
+.container
+  .mt10.mb10.pull-right
+    - if @organizations.any?
+      = link_to t(:'admin.organizations.export'), export_admin_organizations_path, class: 'btn btn-default mr10'
+    = link_to t(:'admin.organizations.add'), new_admin_organization_path, class: 'btn btn-primary'
+
+  table.table.table-striped.mb15.mt15.full-width
+  table.table.table-striped.mb15.mt15.full-width
+    colgroup
+      col style="width: 80%"
+      col style="width: 20%"
+    thead
+      tr
+        th = t(:'admin.organizations.name')
+        th = t(:'admin.organizations.actions')
+    tbody
+      - @organizations.each do |organization|
+        tr
+          td = organization.name
+          td.nowrap
+            = link_to t(:'admin.organizations.edit'), edit_admin_organization_path(organization),
+              class: 'btn btn-primary btn-xs mr5'
+            = link_to t(:'admin.organizations.delete'), admin_organization_path(organization),
+              method: :delete,
+              class: 'btn btn-primary btn-xs',
+              data: {confirm: t(:'admin.organizations.confirm_delete')}
+  = will_paginate @organizations

--- a/app/views/admin/organizations/new.html.slim
+++ b/app/views/admin/organizations/new.html.slim
@@ -1,0 +1,9 @@
+- content_for :page_header_slim
+= render Global::PageHeader.new(t(:'admin.organizations.headline'), subtitle: t(:'admin.page_header'), type: :slim)
+
+.container
+  .row
+    .col-md-12
+      h2
+        = t(:'admin.organizations.add')
+      = render 'admin/organizations/form', organization: @organization

--- a/clients/xikolo-account/lib/xikolo/account/user.rb
+++ b/clients/xikolo-account/lib/xikolo/account/user.rb
@@ -18,6 +18,7 @@ class Xikolo::Account::User < Acfs::Resource
   attribute :timezone, :string
   attribute :avatar_url, :string
   attribute :born_at, :date_time
+  attribute :organization_id, :string
   attribute :created_at, :date_time
   attribute :updated_at, :date_time
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2269,6 +2269,7 @@ de:
       new_password: "Neues Passwort"
       password_confirmation: "Passwort bestätigen"
       birthdate: "Geburtsdatum"
+      organization: Organisation
       select_birthdate: "Bitte wählen"
       show_birthdate_on_record: "Sie können in Ihren <a href='%{url}'>Zertifikatseite</a> angeben, ob Ihr Geburtsdatum auf Ihren Leistungsnachweisen angezeigt werden soll."
       combodate_format: "YYYY-MM-DD"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -296,6 +296,9 @@ de:
       classifier_created: Das Tag wurde angelegt.
       classifiers_order_updated: Die Reihenfolge der Tags wurde geändert.
       cluster_updated: Die Kategorie wurde geändert.
+      organization_created: Die Organisation wurde erfolgreich erstellt.
+      organization_updated: Die Organisation wurde erfolgreich aktualisiert.
+      organization_deleted: Die Organisation wurde erfolgreich gelöscht.
       poll_created: Die Umfrage wurde angelegt.
       poll_updated: Die Umfrage wurde gespeichert.
       poll_deleted: Die Umfrage wurde gelöscht.
@@ -380,6 +383,9 @@ de:
       cluster_not_updated: Die Kategorie wurde nicht geändert.
       classifier_not_deleted: Das Tag konnte nicht gelöscht werden.
       classifier_not_updated: Das Tag wurde nicht geändert.
+      organization_not_created: Die Organisation konnte nicht erstellt werden.
+      organization_not_updated: Die Organisation konnte nicht aktualisiert werden.
+      organization_not_deleted: Die Organisation konnte nicht gelöscht werden.
       poll_not_created: Die Umfrage wurde nicht angelegt.
       poll_not_updated: Die Umfrage wurde nicht gespeichert.
       poll_not_deleted: Die Umfrage wurde nicht gelöscht.
@@ -624,6 +630,7 @@ de:
         user_tests: Nutzertests
         vouchers: Vouchers
         lti_providers: LTI-Anbieter
+        organizations: Organisationen
       masquerade:
         copy_user_id: User ID to Clipboard
         copy_email: E-Mail to Clipboard
@@ -986,6 +993,15 @@ de:
         info: Sie können die Tags durch Ziehen und Ablegen sortieren. Die Reihenfolge wird überall dort verwendet, wo Tags aufgelistet sind, z.B. in den Kategorie-Filtern für die Kursliste.
         back_to_list: Zurück zur Kategorie
         empty_msg: Es gibt derzeit keine Tags für diese Kategorie.
+    organizations:
+      headline: Organisationen
+      name: Name
+      add: Neue Organisation hinzufügen
+      export: Organisationen exportieren
+      edit: Bearbeiten
+      delete: Löschen
+      confirm_delete: Diese Aktion kann nicht rückgängig gemacht werden und wird die Organisation dauerhaft löschen.
+      actions: Aktionen
     courses:
       new: Kurs erstellen
       update: Kurs aktualisieren

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -480,6 +480,7 @@ de:
 
   interrupts:
     mandatory_profile_fields: Bitte helfen Sie uns dabei, Ihre Lernerfahrung weiter zu verbessern. Füllen Sie dafür die erforderlichen Felder aus, bevor Sie mit Ihren Kursen fortfahren.
+    unselected_organization: Um Ihr Lernerlebnis zu verbessern, wählen Sie bitte eine Organisation aus, bevor Sie mit Ihren Kursen fortfahren.
 
   browser_warning:
     headline: Ihr Browser wird nicht unterstützt!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3030,6 +3030,7 @@ en:
       new_password: "New password"
       password_confirmation: "Confirm password"
       birthdate: "Date of birth"
+      organization: Organization
       select_birthdate: "Please select"
       show_birthdate_on_record: "You can decide in your <a href='%{url}'>certificates page</a> if you want your certificates to show your date of birth."
       combodate_format: "YYYY-MM-DD"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,6 +381,9 @@ en:
       classifier_created: The tag has been created.
       classifiers_order_updated: The tag order has been updated.
       cluster_updated: The category has been updated.
+      organization_created: The organization has been successfully created.
+      organization_updated: The organization has been successfully updated.
+      organization_deleted: The organization has been successfully deleted.
       offer_created: The offer has been created.
       offer_updated: The offer has been updated.
       offer_deleted: The offer has been deleted.
@@ -469,6 +472,9 @@ en:
       classifier_not_deleted: The tag was not deleted.
       classifier_not_updated: The tag was not updated.
       classifier_not_created: The tag was not created.
+      organization_not_created: The organization could not be created.
+      organization_not_updated: The organization could not be updated.
+      organization_not_deleted: The organization could not be deleted.
       poll_not_created: The poll has not been created.
       poll_not_updated: The poll has not been updated.
       poll_not_deleted: The poll has not been deleted.
@@ -719,6 +725,7 @@ en:
         user_tests: User Tests
         vouchers: Vouchers
         lti_providers: LTI Providers
+        organizations: Organizations
       masquerade:
         copy_user_id: User ID to Clipboard
         copy_email: E-Mail to Clipboard
@@ -1115,6 +1122,15 @@ en:
         info: You can sort the tags by drag and drop. The order is used everywhere tags are listed, e.g., in the category filters on the course list.
         back_to_list: Back to category
         empty_msg: There are currently no tags for this category.
+    organizations:
+      headline: Organizations
+      name: Name
+      add: Add new organization
+      export: Export organizations
+      edit: Edit
+      delete: Delete
+      confirm_delete: This action cannot be undone and will permanently delete the organization.
+      actions: Actions
     courses:
       new: Create course
       update: Update course

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,7 @@ en:
 
   interrupts:
     mandatory_profile_fields: To help us improve your learning experience, please fill out the required fields before proceeding on to your courses.
+    unselected_organization: To help us improve your learning experience, please select an organization before proceeding on to your courses.
 
   browser_warning:
     headline: Your browser is not supported!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -395,6 +395,11 @@ Rails.application.routes.draw do
         resource :sync, only: %i[create], controller: 'video_provider_sync', as: :sync_video_provider
       end
     end
+    resources :organizations, except: [:show] do
+      collection do
+        get :export
+      end
+    end
   end
 
   # all routes for go, the shortcut for redirects etc.

--- a/db/migrate/20250404104555_create_organizations.rb
+++ b/db/migrate/20250404104555_create_organizations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateOrganizations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :organizations, id: :uuid do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250409083831_add_organization_id_to_users.rb
+++ b/db/migrate/20250409083831_add_organization_id_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIDToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :users, :organization, type: :uuid, foreign_key: true, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_25_101640) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_04_104555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_trgm"
@@ -930,6 +930,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_25_101640) do
     t.string "type", default: "OpenBadge"
     t.index ["record_id", "template_id"], name: "index_open_badges_on_record_id_and_template_id"
     t.index ["type"], name: "index_open_badges_on_type"
+  end
+
+  create_table "organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "pages", id: :uuid, default: -> { "uuid_generate_v7ms()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_04_104555) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_09_083831) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_trgm"
@@ -1646,6 +1646,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_04_104555) do
     t.string "avatar_uri"
     t.string "full_name", null: false
     t.date "last_access"
+    t.uuid "organization_id"
     t.index ["archived"], name: "index_users_on_archived"
     t.index ["confirmed"], name: "index_users_on_confirmed"
     t.index ["created_at", "id"], name: "index_users_pagination"
@@ -1656,6 +1657,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_04_104555) do
     t.index ["full_name"], name: "index_users_on_full_name"
     t.index ["full_name"], name: "index_users_on_full_name_gin_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["last_access"], name: "index_users_on_last_access"
+    t.index ["organization_id"], name: "index_users_on_organization_id"
   end
 
   create_table "versions", id: :uuid, default: -> { "uuid_generate_v7ms()" }, force: :cascade do |t|
@@ -1767,6 +1769,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_04_104555) do
   add_foreign_key "nodes", "sections"
   add_foreign_key "question_statistics", "quiz_questions", column: "question_id", on_delete: :cascade
   add_foreign_key "section_progresses", "sections"
+  add_foreign_key "users", "organizations"
 
   create_view "embed_courses", sql_definition: <<-SQL
       SELECT ARRAY( SELECT hstore(classifiers.*) AS hstore

--- a/services/account/app/controllers/api/organizations_controller.rb
+++ b/services/account/app/controllers/api/organizations_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class API::OrganizationsController < API::RESTController
+  respond_to :json
+
+  def create
+    respond_with Organization.create(organization_params), status: :created
+  end
+
+  def update
+    resource.update organization_params
+    respond_with resource
+  end
+
+  def destroy
+    respond_with resource.destroy!
+  end
+
+  private
+
+  def organization_params
+    params.permit(:name)
+  end
+end

--- a/services/account/app/controllers/api/root_controller.rb
+++ b/services/account/app/controllers/api/root_controller.rb
@@ -44,6 +44,8 @@ class API::RootController < API::BaseController
         user_url: user_rfc6570,
         user_ban_url: user_ban_rfc6570,
         users_url: users_rfc6570,
+        organization_url: organization_rfc6570,
+        organizations_url: organizations_rfc6570,
       }
     end
   end

--- a/services/account/app/controllers/api/users_controller.rb
+++ b/services/account/app/controllers/api/users_controller.rb
@@ -176,6 +176,7 @@ class API::UsersController < API::RESTController
       language
       password
       password_digest
+      organization_id
     ]
   end
 end

--- a/services/account/app/decorators/organization_decorator.rb
+++ b/services/account/app/decorators/organization_decorator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class OrganizationDecorator < ApplicationDecorator
+  delegate_all
+
+  def as_json(opts = {})
+    {
+      id: model.id,
+      name: model.name,
+    }.as_json(opts)
+  end
+end

--- a/services/account/app/decorators/user_decorator.rb
+++ b/services/account/app/decorators/user_decorator.rb
@@ -24,6 +24,7 @@ class UserDecorator < ApplicationDecorator
     accepted_policy_version
     policy_accepted
     timezone
+    organization_id
 
     language
     preferred_language

--- a/services/account/app/models/concerns/session_interrupt.rb
+++ b/services/account/app/models/concerns/session_interrupt.rb
@@ -9,6 +9,7 @@ module SessionInterrupt
     @interrupts ||= [
       new_consents,
       new_policy,
+      unselected_organization,
       mandatory_profile_fields,
     ].compact
   end
@@ -21,6 +22,10 @@ module SessionInterrupt
 
   def new_policy
     'new_policy' unless user.policy_accepted?
+  end
+
+  def unselected_organization
+    'unselected_organization' unless user.organization
   end
 
   def mandatory_profile_fields

--- a/services/account/app/models/organization.rb
+++ b/services/account/app/models/organization.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Organization < ApplicationRecord
+end

--- a/services/account/app/models/organization.rb
+++ b/services/account/app/models/organization.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  has_many :users, dependent: :nullify
 end

--- a/services/account/app/models/user.rb
+++ b/services/account/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ApplicationRecord
   has_many :grants, as: :principal, dependent: :destroy, inverse_of: :principal
   has_many :features, as: :owner, dependent: :destroy, inverse_of: :owner
   has_many :tokens, dependent: :destroy
+  belongs_to :organization, optional: true
 
   has_one :primary_email, -> { primary }, class_name: 'Email', inverse_of: false
 

--- a/services/account/config/routes.rb
+++ b/services/account/config/routes.rb
@@ -48,6 +48,8 @@ Xikolo::Account::Application.routes.draw do
       get    'profile_field_stats/:id', to: 'profile_field_stats#show', as: 'profile_field_stats'
     end
 
+    resources :organizations, only: %i[create update destroy]
+
     resources :memberships, only: %i[create show destroy]
     delete 'memberships' => 'memberships#delete'
 

--- a/services/account/spec/controllers/api/organizations_controller_spec.rb
+++ b/services/account/spec/controllers/api/organizations_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe API::OrganizationsController, type: :controller do
+  let(:params) { {} }
+  let(:organization) { create(:organization) }
+
+  before { organization }
+
+  describe '#create' do
+    subject(:response) { post :create, params: }
+
+    let(:params) { {name: 'Organization A'} }
+
+    it { expect { response }.to change(Organization, :count).by(1) }
+    it { is_expected.to have_http_status :created }
+
+    describe 'JSON' do
+      subject(:json) { JSON.parse(response.body) }
+
+      it 'is the created organization record' do
+        expect(json).to include \
+          'id',
+          'name' => params[:name]
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:response) { patch :update, params: }
+
+    let(:params) { {id: organization.id, name: 'Organization Updated'} }
+
+    it { is_expected.to have_http_status :ok }
+
+    it 'updates the organization record' do
+      response
+      expect(organization.reload.name).to eq(params[:name])
+    end
+
+    describe 'JSON' do
+      subject(:json) { JSON.parse(response.body) }
+
+      it 'is the updated organization record' do
+        expect(json).to include \
+          'id' => organization.id,
+          'name' => params[:name]
+      end
+    end
+  end
+
+  describe '#destroy' do
+    subject(:response) { delete :destroy, params: }
+
+    let(:params) { {id: organization.id} }
+
+    it { is_expected.to have_http_status :ok }
+
+    it 'deletes the organization record' do
+      expect { response }.to change(Organization, :count).from(1).to(0)
+    end
+
+    describe 'JSON' do
+      subject(:json) { JSON.parse(response.body) }
+
+      it 'is the deleted organization record' do
+        expect(json).to include \
+          'id' => organization.id,
+          'name' => organization.name
+      end
+    end
+  end
+end

--- a/services/account/spec/controllers/api/root_controller_spec.rb
+++ b/services/account/spec/controllers/api/root_controller_spec.rb
@@ -39,6 +39,8 @@ describe API::RootController, type: :request do
         user
         user_ban
         users
+        organization
+        organizations
       ]
     end
   end
@@ -191,6 +193,18 @@ describe API::RootController, type: :request do
     subject { super().rel(:users).template.variables }
 
     it { is_expected.to eq %w[search query archived confirmed id permission context auth_uid] }
+  end
+
+  context 'rel(organization)' do
+    subject { super().rel(:organization).template.variables }
+
+    it { is_expected.to eq %w[id] }
+  end
+
+  context 'rel(organizations)' do
+    subject { super().rel(:organizations).template.variables }
+
+    it { is_expected.to eq %w[] }
   end
 
   describe 'response' do

--- a/services/account/spec/decorators/organization_decorator_spec.rb
+++ b/services/account/spec/decorators/organization_decorator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OrganizationDecorator, type: :decorator do
+  let(:organization) { create(:organization) }
+  let(:decorator) { described_class.new organization }
+
+  describe '#as_json' do
+    subject(:json) { decorator.as_json }
+
+    it 'includes the correct properties' do
+      expect(json.keys).to match_array %w[
+        id
+        name
+      ]
+    end
+
+    it { is_expected.to include 'id' => organization.id }
+    it { is_expected.to include 'name' => organization.name }
+  end
+end

--- a/services/account/spec/decorators/user_decorator_spec.rb
+++ b/services/account/spec/decorators/user_decorator_spec.rb
@@ -31,6 +31,7 @@ describe UserDecorator, type: :decorator do
         affiliated
         affiliation
         password_digest
+        organization_id
         created_at
         updated_at
 
@@ -66,6 +67,7 @@ describe UserDecorator, type: :decorator do
     it { is_expected.to include 'full_name' => user.full_name }
     it { is_expected.to include 'affiliated' => user.affiliated? }
     it { is_expected.to include 'password_digest' => user.password_digest }
+    it { is_expected.to include 'organization_id' => user.organization_id }
     it { is_expected.to include 'created_at' => user.created_at.iso8601 }
     it { is_expected.to include 'updated_at' => user.updated_at.iso8601 }
 

--- a/services/account/spec/factories.rb
+++ b/services/account/spec/factories.rb
@@ -238,4 +238,8 @@ FactoryBot.define do
     value { true }
     created_at { 5.years.ago }
   end
+
+  factory :organization do
+    name { 'Organization' }
+  end
 end

--- a/services/account/spec/factories.rb
+++ b/services/account/spec/factories.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
   factory :user do
     transient do
       completed_profile { true }
+      with_organization { true }
     end
 
     password { 'secret123' }
@@ -23,6 +24,10 @@ FactoryBot.define do
           value: 'true',
           context: Context.root
         )
+      end
+
+      if evaluator.with_organization
+        user.organization = create(:organization)
       end
 
       create(:email, user:, primary: true, confirmed: true)

--- a/services/account/spec/requests/api/sessions/show_spec.rb
+++ b/services/account/spec/requests/api/sessions/show_spec.rb
@@ -88,6 +88,13 @@ describe 'Sessions: Show', type: :request do
       end
     end
 
+    context 'with unselected organization' do
+      let(:session) { create(:session, user: create(:user, with_organization: false)) }
+
+      it { expect(resource['interrupt']).to be true }
+      it { expect(resource['interrupts']).to eq ['unselected_organization'] }
+    end
+
     context 'with incomplete profile' do
       let(:session) { create(:session, user: create(:user, completed_profile: false)) }
 

--- a/services/notification/app/consumers/account_consumer.rb
+++ b/services/notification/app/consumers/account_consumer.rb
@@ -29,7 +29,7 @@ class AccountConsumer < Msgr::Consumer
 
     features = user.rel(:features).get.value!
 
-    mandatory_fields = features.key?('account.profile.mandatory_completed')
+    mandatory_fields = user.organization_id.present? && features.key?('account.profile.mandatory_completed')
     url = payload[:confirmation_url]
 
     deliver AccountMailer.welcome_email(user, mandatory_fields, url)

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Admin::OrganizationsController, type: :controller do
+  let(:user_id) { SecureRandom.uuid }
+  let(:permissions) { ['account.organizations.manage'] }
+  let(:organization) { create(:organization) }
+
+  before do
+    stub_user(id: user_id, language: 'en', permissions:)
+
+    Stub.service(:account,
+      session_url: '/sessions/{id}',
+      organizations_url: '/organizations',
+      organization_url: '/organizations/{id}')
+  end
+
+  describe 'GET index' do
+    let(:params) { {page: '1'} }
+
+    it 'answers with a page' do
+      get :index, params: params
+      expect(response).to be_successful
+      expect(response).to render_template(:index)
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        get :index, params: params
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'GET new' do
+    it 'answers with a page' do
+      get :new
+      expect(response).to be_successful
+      expect(response).to render_template(:new)
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        get :new
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let(:params) { {id: organization.id} }
+
+    it 'finds the organization and renders the edit template' do
+      get :edit, params: params
+      expect(response).to be_successful
+      expect(response).to render_template(:edit)
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        get :edit, params: params
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'POST create' do
+    let(:params) { {name: 'New Organization'} }
+
+    context 'when the API request is successful' do
+      before do
+        Stub.request(
+          :account, :post, '/organizations'
+        ).to_return Stub.json(organization)
+      end
+
+      it 'creates a organization and redirects with success message' do
+        post :create, params: {account_organization: params}
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:success].first).to eq(I18n.t(:'flash.success.organization_created'))
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        Stub.request(
+          :account, :post, '/organizations'
+        ).to_return(status: 400, body: {errors: ['Invalid organization name']}.to_json)
+      end
+
+      it 'redirects with an error message' do
+        post :create, params: {account_organization: params}
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:error].first).to eq(I18n.t(:'flash.error.organization_not_created'))
+      end
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        post :create, params: {account_organization: params}
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'PATCH update' do
+    let(:params) { {name: 'Updated Organization'} }
+
+    context 'when the API request is successful' do
+      before do
+        Stub.request(
+          :account, :patch, "/organizations/#{organization.id}"
+        ).to_return Stub.json(organization)
+      end
+
+      it 'updates the organization and redirects with success message' do
+        patch :update, params: {id: organization.id, account_organization: params}
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:success].first).to eq(I18n.t(:'flash.success.organization_updated'))
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        Stub.request(
+          :account, :patch, "/organizations/#{organization.id}"
+        ).to_return(status: 400, body: {errors: ['Invalid organization name']}.to_json)
+      end
+
+      it 'redirects with an error message' do
+        patch :update, params: {id: organization.id, account_organization: params}
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:error].first).to eq(I18n.t(:'flash.error.organization_not_updated'))
+      end
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        patch :update, params: {id: organization.id, account_organization: params}
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let(:params) { {id: organization.id} }
+
+    context 'when the API request is successful' do
+      before do
+        Stub.request(
+          :account, :delete, "/organizations/#{organization.id}"
+        ).to_return(status: 204)
+      end
+
+      it 'deletes the organization and redirects with success message' do
+        delete :destroy, params: params
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:success].first).to eq(I18n.t(:'flash.success.organization_deleted'))
+      end
+    end
+
+    context 'when the API request fails' do
+      before do
+        Stub.request(
+          :account, :delete, "/organizations/#{organization.id}"
+        ).to_return(status: 404, body: {errors: ['The organization was not found']}.to_json)
+      end
+
+      it 'redirects with an error message' do
+        delete :destroy, params: params
+        expect(response).to redirect_to(admin_organizations_path)
+        expect(flash[:error].first).to eq(I18n.t(:'flash.error.organization_not_deleted'))
+      end
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        delete :destroy, params: params
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe 'GET export' do
+    it 'answers with a csv attachment' do
+      get :export
+
+      expect(response).to be_successful
+      expect(response.headers['Content-Type']).to eq('text/csv')
+      expect(response.headers['Content-Disposition']).to include('attachment')
+    end
+
+    context 'without account.organizations.manage permission' do
+      let(:permissions) { [] }
+
+      it 'cannot access the page' do
+        get :export
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+end

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -179,4 +179,8 @@ FactoryBot.define do
       value { false }
     end
   end
+
+  factory :organization, class: 'Account::Organization' do
+    name { 'Organization' }
+  end
 end

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -4,10 +4,20 @@ require 'xikolo/common/rspec'
 
 FactoryBot.define do
   factory :user, class: 'Account::User' do
+    transient do
+      with_organization { true }
+    end
+
     id { generate(:user_id) }
     sequence(:full_name) {|n| "User Fullname #{n}" }
     sequence(:display_name) {|n| "User Displayname #{n}" }
     language { 'en' }
+
+    after(:create) do |user, evaluator|
+      if evaluator.with_organization
+        user.organization = create(:organization)
+      end
+    end
 
     trait :with_email do
       after(:create) do |user|

--- a/spec/requests/interrupts/known_interrupts_spec.rb
+++ b/spec/requests/interrupts/known_interrupts_spec.rb
@@ -33,6 +33,20 @@ describe 'Interrupts: Known interrupt types', type: :request do
     it { is_expected.to redirect_to '/account/policies' }
   end
 
+  context 'with unselected_organization interrupt' do
+    let(:interrupts) { ['unselected_organization'] }
+
+    context 'with the profile feature flipper' do
+      let(:features) { {'profile' => 'true'} }
+
+      it { is_expected.to redirect_to '/dashboard/profile' }
+    end
+
+    context 'without the profile feature flipper' do
+      it { is_expected.to have_http_status :ok }
+    end
+  end
+
   context 'with mandatory_profile_fields interrupt' do
     let(:interrupts) { ['mandatory_profile_fields'] }
 

--- a/spec/requests/interrupts/priority_spec.rb
+++ b/spec/requests/interrupts/priority_spec.rb
@@ -19,7 +19,7 @@ describe 'Interrupts: Priority of multiple interrupts', type: :request do
   let(:interrupts) { [] }
 
   context 'in order of priority' do
-    let(:interrupts) { %w[new_consents new_policy mandatory_profile_fields] }
+    let(:interrupts) { %w[new_consents new_policy unselected_organization mandatory_profile_fields] }
 
     it 'redirects to the most important interrupt (new consent required)' do
       request
@@ -28,7 +28,7 @@ describe 'Interrupts: Priority of multiple interrupts', type: :request do
   end
 
   context 'in different order' do
-    let(:interrupts) { %w[new_policy mandatory_profile_fields new_consents] }
+    let(:interrupts) { %w[new_policy mandatory_profile_fields unselected_organization new_consents] }
 
     it 'still redirects to the most important interrupt (new consent required)' do
       request

--- a/spec/requests/interrupts/redirect_spec.rb
+++ b/spec/requests/interrupts/redirect_spec.rb
@@ -16,48 +16,99 @@ describe 'Interrupts: Redirect targets / messages', type: :request do
       interrupts:
     )
   end
-  let(:interrupts) { %w[mandatory_profile_fields] }
+  let(:interrupts) { %w[] }
 
-  context 'on another page where interrupts are checked' do
-    let(:page) { '/dashboard' }
+  context 'with mandatory_profile_fields' do
+    let(:interrupts) { %w[mandatory_profile_fields] }
 
-    it 'redirects to interrupt target' do
-      request
-      expect(response).to redirect_to '/dashboard/profile'
+    context 'on another page where interrupts are checked' do
+      let(:page) { '/dashboard' }
+
+      it 'redirects to interrupt target' do
+        request
+        expect(response).to redirect_to '/dashboard/profile'
+      end
+    end
+
+    context 'on target page of interrupt' do
+      let(:page) { '/dashboard/profile' }
+
+      before do
+        Stub.request(:account, :get, "/users/#{user[:id]}")
+          .to_return Stub.json(user)
+        Stub.request(:account, :get, "/users/#{user[:id]}/emails")
+          .to_return Stub.json([])
+        Stub.request(:account, :get, "/users/#{user[:id]}/consents")
+          .to_return Stub.json([])
+        Stub.request(:account, :get, "/users/#{user[:id]}/profile")
+          .to_return Stub.json({fields: []})
+        Stub.request(
+          :account, :get, '/authorizations',
+          query: {user: user[:id]}
+        ).to_return Stub.json([])
+      end
+
+      it 'stays on the page' do
+        request
+        expect(response).to have_http_status :ok
+      end
+    end
+
+    context 'on target page of a less important interrupt' do
+      let(:page) { '/dashboard/profile' }
+      let(:interrupts) { %w[new_consents mandatory_profile_fields] }
+
+      it 'redirects to most important interrupt target' do
+        request
+        expect(response).to redirect_to '/treatments'
+      end
     end
   end
 
-  context 'on target page of interrupt' do
-    let(:page) { '/dashboard/profile' }
+  context 'with unselected_organization' do
+    let(:interrupts) { %w[unselected_organization] }
 
-    before do
-      Stub.request(:account, :get, "/users/#{user[:id]}")
-        .to_return Stub.json(user)
-      Stub.request(:account, :get, "/users/#{user[:id]}/emails")
-        .to_return Stub.json([])
-      Stub.request(:account, :get, "/users/#{user[:id]}/consents")
-        .to_return Stub.json([])
-      Stub.request(:account, :get, "/users/#{user[:id]}/profile")
-        .to_return Stub.json({fields: []})
-      Stub.request(
-        :account, :get, '/authorizations',
-        query: {user: user[:id]}
-      ).to_return Stub.json([])
+    context 'on another page where interrupts are checked' do
+      let(:page) { '/dashboard' }
+
+      it 'redirects to interrupt target' do
+        request
+        expect(response).to redirect_to '/dashboard/profile'
+      end
     end
 
-    it 'stays on the page' do
-      request
-      expect(response).to have_http_status :ok
+    context 'on target page of interrupt' do
+      let(:page) { '/dashboard/profile' }
+
+      before do
+        Stub.request(:account, :get, "/users/#{user[:id]}")
+          .to_return Stub.json(user)
+        Stub.request(:account, :get, "/users/#{user[:id]}/emails")
+          .to_return Stub.json([])
+        Stub.request(:account, :get, "/users/#{user[:id]}/consents")
+          .to_return Stub.json([])
+        Stub.request(:account, :get, "/users/#{user[:id]}/profile")
+          .to_return Stub.json({fields: []})
+        Stub.request(
+          :account, :get, '/authorizations',
+          query: {user: user[:id]}
+        ).to_return Stub.json([])
+      end
+
+      it 'stays on the page' do
+        request
+        expect(response).to have_http_status :ok
+      end
     end
-  end
 
-  context 'on target page of a less important interrupt' do
-    let(:page) { '/dashboard/profile' }
-    let(:interrupts) { %w[new_consents mandatory_profile_fields] }
+    context 'on target page of a less important interrupt' do
+      let(:page) { '/dashboard/profile' }
+      let(:interrupts) { %w[new_consents unselected_organization] }
 
-    it 'redirects to most important interrupt target' do
-      request
-      expect(response).to redirect_to '/treatments'
+      it 'redirects to most important interrupt target' do
+        request
+        expect(response).to redirect_to '/treatments'
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request replaces the old functionality, where user assignments to municipalities were managed via a required field in the user profile. The previous approach did not support effective management of municipalities.  

The new approach introduces a dedicated `organizations` table (not municipalities, to make it suitable also for other use cases) and a new admin interface for managing and exporting organizations. Additionally, an `organization_id` column has been added to the `users` table, and a corresponding field has been added to the user profile page. To ensure proper data entry, an `unselected_organization` session interrupt mechanism redirects users to the profile page until the field is set.  

Migrating from the old approach to the new one must be handled manually. This includes: 
- Populating the `organizations` table based on the available values of the `kommune` `custom_field`.  
- Assigning organizations to users based on the current `custom_fields_values`.  
- Adding the new permission `account.organizations.manage` to the `admin` role.  
- Removing the `kommune` custom field and its corresponding values. 

![image](https://github.com/user-attachments/assets/1938d4ad-3036-4d2b-ac49-e2dd7fd1a373)

![image](https://github.com/user-attachments/assets/439eb020-100a-4cf7-a77c-313ced1645cb)

![image](https://github.com/user-attachments/assets/de743ff7-4b33-4f04-93cb-afef97d7dde2)
